### PR TITLE
Corrected paths of WebAssembly/pas2js fpcupdeluxe installation

### DIFF
--- a/htdocs/doc/web.adoc
+++ b/htdocs/doc/web.adoc
@@ -153,7 +153,7 @@ After installing FPC (and Pas2js) using the _WA_ button:
 --
 1. `<chosen_installation_path>/fpc/bin/<target>/pas2js`: Do not use this. It is not accompanied by the `pas2js.cfg`, and trying to use it will fail with message `Error: can't find unit "System"`.
 
-2. `<chosen_installation_path>/ccr/pas2js-rtl/tools/pas2js`: Use this.
+2. `<chosen_installation_path>/ccr/pas2js-rtl/bin/(target)/pas2js`: Use this.
 --
 +
 To make it work, we recommend to:
@@ -161,7 +161,8 @@ To make it work, we recommend to:
 --
 1. Simply remove the `<chosen_installation_path>/fpc/bin/<target>/pas2js` executable (it has `.exe` extension on Windows).
 
-2. Place the `<chosen_installation_path>/ccr/pas2js-rtl/tools/` directory on your `$PATH`. This way our editor will find the correct `pas2js` and it will also be available from the command-line.
+2. Place the `<chosen_installation_path>/ccr/pas2js-rtl/bin/(target)` directory on your `$PATH`. This way our editor will find the correct `pas2js` and it will also be available from the command-line.
+3. Restart the editor for `$PATH` changes to take effect.
 --
 
 ==== Prerequisites using manual installation

--- a/htdocs/doc/web.adoc
+++ b/htdocs/doc/web.adoc
@@ -153,7 +153,7 @@ After installing FPC (and Pas2js) using the _WA_ button:
 --
 1. `<chosen_installation_path>/fpc/bin/<target>/pas2js`: Do not use this. It is not accompanied by the `pas2js.cfg`, and trying to use it will fail with message `Error: can't find unit "System"`.
 
-2. `<chosen_installation_path>/ccr/pas2js-rtl/bin/(target)/pas2js`: Use this.
+2. `<chosen_installation_path>/ccr/pas2js-rtl/bin/<target>/pas2js`: Use this.
 --
 +
 To make it work, we recommend to:
@@ -161,8 +161,14 @@ To make it work, we recommend to:
 --
 1. Simply remove the `<chosen_installation_path>/fpc/bin/<target>/pas2js` executable (it has `.exe` extension on Windows).
 
-2. Place the `<chosen_installation_path>/ccr/pas2js-rtl/bin/(target)` directory on your `$PATH`. This way our editor will find the correct `pas2js` and it will also be available from the command-line.
-3. Restart the editor for `$PATH` changes to take effect.
+2. Place the `<chosen_installation_path>/ccr/pas2js-rtl/bin/<target>` directory on your `$PATH`. This way our editor will find the correct `pas2js` and it will also be available from the command-line.
+
+3. To make link:editor[] see the the `$PATH` changes:
++
+** _On Windows_, restart the editor.
+** _On Unix_ (if you changed `PATH` in your shell file like `~/.bashrc`), you can start the editor from the terminal running a new shell process (with new environment variables, check by `echo $PATH`).
+** In general, you need to restart link:editor[] and all its parent processes that propagate environment variables.
+** If the above doesn't work or sounds too complicated, just logout and login again, and run the editor again.
 --
 
 ==== Prerequisites using manual installation


### PR DESCRIPTION
I wanted to confirm that WA button works good in FPCUPDeluxe, and bumped also to the same issue with wrong executable (on windows, which you described in the docs and in PR comment). However I couldn't confirm the overall process before as I had some issue with one of my submodules under fpc3.3 
Now I came back to this and made the whole process again and followed your instruction as well , to be precise. I noticed (at least for windows) paths need tiny correction. 
